### PR TITLE
Try to get Android player and queue working properly

### DIFF
--- a/src/components/PVSortableList.tsx
+++ b/src/components/PVSortableList.tsx
@@ -21,6 +21,7 @@ export class PVSortableList extends React.Component<Props, State> {
         onPressRow={onPressRow}
         onReleaseRow={onReleaseRow}
         renderRow={renderRow}
+        rowActivationTime={500}
         style={styles.list} />
     )
   }

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -407,11 +407,11 @@ export const setPlaybackPositionWhenDurationIsAvailable = async (
           } else {
             await TrackPlayer.seekTo(position)
           }
-        }, 500)
+        }, 250)
         resolve()
       }
       if (resolveImmediately) resolve()
-    }, 500)
+    }, 250)
   })
 }
 

--- a/src/services/playerEvents.ts
+++ b/src/services/playerEvents.ts
@@ -75,7 +75,7 @@ module.exports = async () => {
           await addOrUpdateHistoryItem(nowPlayingItem)
         }
       } else if (Platform.OS === 'android') {
-
+        // TODO add android playback-state logic
       }
     }
   })

--- a/src/services/playerEvents.ts
+++ b/src/services/playerEvents.ts
@@ -7,6 +7,8 @@ import { getClipHasEnded, getNowPlayingItem, getNowPlayingItemFromQueueOrHistory
   setPlaybackPositionWhenDurationIsAvailable, updateUserPlaybackPosition } from './player'
 import PlayerEventEmitter from './playerEventEmitter'
 
+const debouncedSetPlaybackPosition = debounce(setPlaybackPositionWhenDurationIsAvailable, 1250)
+
 const handleSyncNowPlayingItem = async (trackId: string) => {
   const currentNowPlayingItem = await getNowPlayingItemFromQueueOrHistoryByTrackId(trackId)
   if (!currentNowPlayingItem) return
@@ -15,7 +17,7 @@ const handleSyncNowPlayingItem = async (trackId: string) => {
   PlayerEventEmitter.emit(PV.Events.PLAYER_TRACK_CHANGED)
 
   if (Platform.OS === 'android' && !currentNowPlayingItem.clipId) {
-    setPlaybackPositionWhenDurationIsAvailable(currentNowPlayingItem.userPlaybackPosition, trackId)
+    debouncedSetPlaybackPosition(currentNowPlayingItem.userPlaybackPosition, trackId)
   }
 }
 

--- a/src/services/playerEvents.ts
+++ b/src/services/playerEvents.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native'
 import { NowPlayingItem } from '../lib/NowPlayingItem'
 import { PV } from '../resources'
 import { addOrUpdateHistoryItem } from './history'
@@ -64,13 +65,17 @@ module.exports = async () => {
         await handleResumeAfterClipHasEnded()
       }
 
-      if (x.state === 'paused' || x.state === 'playing') {
-        updateUserPlaybackPosition()
-      } else if (x.state === 'ready' && nowPlayingItem.userPlaybackPosition && !nowPlayingItem.clipId) {
-        await setPlaybackPositionWhenDurationIsAvailable(nowPlayingItem.userPlaybackPosition)
-        await addOrUpdateHistoryItem(nowPlayingItem)
-      } else if (x.state === 'ready') {
-        await addOrUpdateHistoryItem(nowPlayingItem)
+      if (Platform.OS === 'ios') {
+        if (x.state === 'paused' || x.state === 'playing') {
+          updateUserPlaybackPosition()
+        } else if (x.state === 'ready' && nowPlayingItem.userPlaybackPosition && !nowPlayingItem.clipId) {
+          await setPlaybackPositionWhenDurationIsAvailable(nowPlayingItem.userPlaybackPosition)
+          await addOrUpdateHistoryItem(nowPlayingItem)
+        } else if (x.state === 'ready') {
+          await addOrUpdateHistoryItem(nowPlayingItem)
+        }
+      } else if (Platform.OS === 'android') {
+
       }
     }
   })

--- a/src/services/queue.ts
+++ b/src/services/queue.ts
@@ -90,8 +90,8 @@ export const getNextFromQueue = async (moveToHistory?: boolean) => {
   }
 
   if (item && moveToHistory) {
-    await removeQueueItem(item, false)
-    await addOrUpdateHistoryItem(item)
+    removeQueueItem(item, false)
+    addOrUpdateHistoryItem(item)
   }
 
   return item

--- a/src/services/queue.ts
+++ b/src/services/queue.ts
@@ -42,10 +42,9 @@ export const addQueueItemNext = async (item: NowPlayingItem) => {
   try {
     PVTrackPlayer.remove(item.clipId || item.episodeId)
   } catch (error) {
-    console.log('addQueueItemNext', error)
+    console.log('addQueueItemNext service', error)
     //
   }
-
   const playerQueueItems = await PVTrackPlayer.getQueue()
   const currentTrackId = await PVTrackPlayer.getCurrentTrack()
   const currentTrackIndex = playerQueueItems.findIndex((x: any) => currentTrackId === x.id)
@@ -111,7 +110,7 @@ export const removeQueueItem = async (item: NowPlayingItem, removeFromPlayerQueu
     try {
       PVTrackPlayer.remove(item.clipId || item.episodeId)
     } catch (error) {
-      console.log(error)
+      console.log('removeQueueItem service', error)
     }
   }
 

--- a/src/state/actions/player.ts
+++ b/src/state/actions/player.ts
@@ -179,6 +179,7 @@ export const loadNextFromQueue = async (shouldPlay: boolean) => {
 
 export const loadTrackFromQueue = async (
   item: NowPlayingItem, shouldPlay: boolean, skipUpdatePlaybackPosition: boolean, shouldStartClip: boolean) => {
+
   if (item) {
     await updatePlayerState(item)
     await loadTrackFromQueueService(item, shouldPlay, skipUpdatePlaybackPosition, shouldStartClip)

--- a/src/state/actions/player.ts
+++ b/src/state/actions/player.ts
@@ -9,40 +9,30 @@ import { addItemsToPlayerQueueNext as addItemsToPlayerQueueNextService, clearNow
 import { addQueueItemNext, getNextFromQueue } from '../../services/queue'
 
 export const updatePlayerState = async (item: NowPlayingItem) => {
-  return new Promise(async (resolve, reject) => {
-    const globalState = getGlobal()
-    const lastNowPlayingItem = await getNowPlayingItem()
-    const isNewEpisode = !lastNowPlayingItem || (item.episodeId !== lastNowPlayingItem.episodeId)
-    const isNewMediaRef = item.clipId && (!lastNowPlayingItem || item.clipId !== lastNowPlayingItem.clipId)
-    const episode = convertNowPlayingItemToEpisode(item)
-    episode.description = episode.description || 'No show notes available'
-    const mediaRef = convertNowPlayingItemToMediaRef(item)
+  const globalState = getGlobal()
+  const episode = convertNowPlayingItemToEpisode(item)
+  episode.description = episode.description || 'No show notes available'
+  const mediaRef = convertNowPlayingItemToMediaRef(item)
 
-    const newState = {
-      player: {
-        ...globalState.player,
-        episode,
-        ...(isNewMediaRef || !item.clipId ? { mediaRef } : { mediaRef: null }),
-        nowPlayingItem: item,
-        showMiniPlayer: true
-      },
-      screenPlayer: {
-        ...globalState.screenPlayer,
-        showFullClipInfo: false
-      }
-    } as any
-
-    if (isNewEpisode) {
-      newState.screenPlayer = {
-        ...globalState.screenPlayer,
-        isLoading: true,
-        showFullClipInfo: false,
-        viewType: PV.Keys.VIEW_TYPE_SHOW_NOTES
-      }
+  const newState = {
+    player: {
+      ...globalState.player,
+      episode,
+      ...(!item.clipId ? { mediaRef } : { mediaRef: null }),
+      nowPlayingItem: item,
+      showMiniPlayer: true
     }
+  } as any
 
-    setGlobal(newState, () => resolve())
-  })
+  if (!item.clipId) {
+    newState.screenPlayer = {
+      ...globalState.screenPlayer,
+      showFullClipInfo: false,
+      viewType: PV.Keys.VIEW_TYPE_SHOW_NOTES
+    }
+  }
+
+  setGlobal(newState)
 }
 
 export const initializePlayerQueue = async () => {


### PR DESCRIPTION
Ugh. Running into more trickiness and gotchas with the react-native-track-player, this time on Android. I'm starting to think we should maybe be writing player logic for iOS and Android totally separate from one another.

Anyway, I don't recommend merging this just yet. I'm going to test it more extensively tomorrow.