### PR TITLE
Call updateTrackPlayerCapabilities whenever the app goes to the background

### DIFF
--- a/src/screens/PodcastsScreen.tsx
+++ b/src/screens/PodcastsScreen.tsx
@@ -25,7 +25,8 @@ import { getAppUserAgent, setAppUserAgent, setCategoryQueryProperty, testProps }
 import { PV } from '../resources'
 import { assignCategoryQueryToState, assignCategoryToStateForSortSelect, getCategoryLabel } from '../services/category'
 import { getEpisode } from '../services/episode'
-import { checkIdlePlayerState, PVTrackPlayer, updateUserPlaybackPosition } from '../services/player'
+import { checkIdlePlayerState, PVTrackPlayer, updateTrackPlayerCapabilities,
+  updateUserPlaybackPosition } from '../services/player'
 import { getPodcast, getPodcasts } from '../services/podcast'
 import { trackPageView } from '../services/tracking'
 import { getNowPlayingItemLocally } from '../services/userNowPlayingItem'
@@ -161,14 +162,23 @@ export class PodcastsScreen extends React.Component<Props, State> {
     }
 
     if (nextAppState === 'background' || nextAppState === 'inactive') {
+      // NOTE: On iOS TrackPlayer.updateOptions must be called every time the app
+      // goes into the background to prevent the remote controls from disappearing
+      // on the lock screen.
+      // Source: https://github.com/react-native-kit/react-native-track-player/issues/921#issuecomment-686806847
+      if (Platform.OS === 'ios') {
+        updateTrackPlayerCapabilities()
+      }
+
       const currentState = await PVTrackPlayer.getState()
       // If an episode is not playing, then assume its latest playback position does not
       // need to get updated in history.
       // This will also prevent the history from being updated when a user closes the app on Device A,
       // then reloads it to make it load with last history item (currently playing item) on Device B.
       if (currentState === PVTrackPlayer.STATE_PLAYING) {
-        await updateUserPlaybackPosition()
+        updateUserPlaybackPosition()
       }
+
     }
   }
 

--- a/src/services/player.ts
+++ b/src/services/player.ts
@@ -23,10 +23,16 @@ import {
 import { addOrUpdateHistoryItem, getHistoryItemsIndexLocally, getHistoryItemsLocally } from './userHistoryItem'
 import { getNowPlayingItem, getNowPlayingItemLocally } from './userNowPlayingItem'
 
+export const PVTrackPlayer = TrackPlayer
+
 // TODO: setupPlayer is a promise, could this cause an async issue?
 TrackPlayer.setupPlayer({
   waitForBuffer: false
 }).then(() => {
+  updateTrackPlayerCapabilities()
+})
+
+export const updateTrackPlayerCapabilities = () => {
   TrackPlayer.updateOptions({
     capabilities: [
       TrackPlayer.CAPABILITY_JUMP_BACKWARD,
@@ -55,9 +61,7 @@ TrackPlayer.setupPlayer({
     stopWithApp: true,
     jumpInterval: PV.Player.jumpSeconds
   })
-})
-
-export const PVTrackPlayer = TrackPlayer
+}
 
 /*
   state key for android


### PR DESCRIPTION
This is an attempt to prevent a bug where the player buttons disappear from the lockscreen.

Source: https://github.com/react-native-kit/react-native-track-player/issues/921#issuecomment-686806847