### PR TITLE
Podverse 3.1.6-beta.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -133,7 +133,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
-        versionName "3.1.5"
+        versionName "3.1.6"
         multiDexEnabled true
         missingDimensionStrategy 'react-native-camera', 'general'
     }

--- a/ios/podverse.xcodeproj/project.pbxproj
+++ b/ios/podverse.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 				INFOPLIST_FILE = podverse/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.1.5;
+				MARKETING_VERSION = 3.1.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -474,7 +474,7 @@
 				INFOPLIST_FILE = podverse/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 3.1.5;
+				MARKETING_VERSION = 3.1.6;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podverse",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "private": true,
   "contributors": [
     "Creon Creonopoulos",


### PR DESCRIPTION
- Added optional, anonymous, analytics tracking for sorting podcasts by popularity.

- Added the ability to skip to a preset time every time you start playing a podcast. (Click the Gear icon on a podcast page to enable this feature.)

- Fixed bug that prevented boosts from working for some podcasts.

- Fixed bug that caused the Boost button to appear then disappear for some podcasts.

- Fixed bug that caused the Premium RSS Feed login screen to render behind the current screen.