### PR TITLE
Android remote duck handling

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -136,7 +136,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         ndkVersion rootProject.ext.ndkVersion
         versionCode 1
-        versionName "4.2.2"
+        versionName "4.2.3"
         multiDexEnabled true
         missingDimensionStrategy 'store', 'play'
     }

--- a/ios/podverse.xcodeproj/project.pbxproj
+++ b/ios/podverse.xcodeproj/project.pbxproj
@@ -439,7 +439,7 @@
 				INFOPLIST_FILE = podverse/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 4.2.2;
+				MARKETING_VERSION = 4.2.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -474,7 +474,7 @@
 				INFOPLIST_FILE = podverse/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 4.2.2;
+				MARKETING_VERSION = 4.2.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podverse",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "private": true,
   "contributors": [
     "Creon Creonopoulos",

--- a/src/services/playerAudioEvents.ts
+++ b/src/services/playerAudioEvents.ts
@@ -203,7 +203,6 @@ module.exports = async () => {
     playerPlayNextChapterOrQueueItem()
   })
 
-
   /*
     iOS triggers remote-duck with permanent: true when the player app returns to foreground,
     but only in case where the track was paused before app going to background,


### PR DESCRIPTION
Note about `if (permanent && isPlaying) {`:
https://github.com/react-native-kit/react-native-track-player/issues/687#issuecomment-660149163

See #1263 for wasPausedByDuck explanation:
https://github.com/DoubleSymmetry/react-native-track-player/issues/1263

alwaysPauseOnInterruption issues on Android:
https://github.com/DoubleSymmetry/react-native-track-player/issues/1009