### PR TITLE
Added long press functionality to grid items

### DIFF
--- a/src/components/GridView.tsx
+++ b/src/components/GridView.tsx
@@ -9,6 +9,7 @@ type Props = {
   data?: [any]
   isRefreshing: boolean
   onItemSelected: any
+  onLongPressItem?: (arg0: Podcast) => void
   ListFooterComponent: any
 }
 export class GridView extends React.PureComponent<Props> {
@@ -68,6 +69,7 @@ export class GridView extends React.PureComponent<Props> {
           onPress={() => {
             this.props.onItemSelected?.(item)
           }}
+          onLongPress={() => this.props.onLongPressItem?.(item)}
           style={styles.cellbutton}>
           <FastImage
             isAddByRSSPodcast={!!item?.addByRSSPodcastFeedUrl}

--- a/src/components/PVActionSheet.tsx
+++ b/src/components/PVActionSheet.tsx
@@ -45,7 +45,7 @@ export class PVActionSheet extends React.Component<Props, State> {
 
     if (items && items.length >= 0) {
       items.forEach((item, index) => {
-        const buttonStyle = [actionSheetStyles.button]
+        let buttonStyle = [actionSheetStyles.button]
 
         if (item.key === PV.Keys.edit_clip) {
           buttonStyle.push(actionSheetStyles.buttonTop)
@@ -102,6 +102,8 @@ export class PVActionSheet extends React.Component<Props, State> {
         let onPress = item.onPress
         if (isQueueButton) onPress = queueOnPress
 
+        buttonStyle = [...buttonStyle, (item?.buttonStyle ?? {})]
+        buttonTextStyle = {...buttonTextStyle, ...(item?.buttonTextStyle ?? {})}
         buttons.push(
           <TouchableHighlight
             accessible

--- a/src/components/PVFlatList.tsx
+++ b/src/components/PVFlatList.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Podcast } from 'podverse-shared'
 import { RefreshControl, StyleSheet } from 'react-native'
 import { SwipeListView } from 'react-native-swipe-list-view'
 import { useGlobal } from 'reactn'
@@ -40,6 +41,7 @@ type Props = {
   onEndReached?: any
   onEndReachedThreshold?: number
   onGridItemSelected?: any
+  onGridItemLongPressed?: (arg0: Podcast) => void
   onRefresh?: any
   onScrollBeginDrag?: any
   renderHiddenItem?: any
@@ -89,6 +91,7 @@ export const PVFlatList = (props: Props) => {
     onEndReached,
     onEndReachedThreshold = 0.9,
     onGridItemSelected,
+    onGridItemLongPressed,
     onRefresh,
     onScrollBeginDrag,
     renderHiddenItem,
@@ -125,6 +128,7 @@ export const PVFlatList = (props: Props) => {
         <GridView
           {...props}
           onItemSelected={onGridItemSelected}
+          onLongPressItem={onGridItemLongPressed}
           data={shouldShowResults ? data : []}
           ListFooterComponent={() => {
             if (isLoadingMore && !isEndOfResults) {

--- a/src/components/SwipeRowBackMultipleButtons.tsx
+++ b/src/components/SwipeRowBackMultipleButtons.tsx
@@ -26,8 +26,11 @@ export const SwipeRowBackMultipleButtons = (props: Props) => {
 
     for (const button of buttons) {
       const style = [s.swipeRowBackButton]
+      const textStyle = [s.textWrapper]
+
       if (button.type === 'danger') {
         style.push(globalTheme.swipeRowBackButtonDanger)
+        textStyle.push({color:PV.Colors.white})
       } else {
         style.push(globalTheme.swipeRowBackButtonPrimary)
       }
@@ -43,7 +46,7 @@ export const SwipeRowBackMultipleButtons = (props: Props) => {
           {button.isLoading ? (
             <ActivityIndicator accessible={false} importantForAccessibility='no' size='large' testID={testID} />
           ) : (
-            <Text accessible={false} importantForAccessibility='no' style={s.textWrapper}>
+            <Text accessible={false} importantForAccessibility='no' style={textStyle}>
               {button.text}
             </Text>
           )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9028,7 +9028,7 @@ react-native-vector-icons@8.1.0:
     prop-types "^15.7.2"
     yargs "^16.1.1"
 
-react-native-video-controls@^2.8.1:
+react-native-video-controls@2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/react-native-video-controls/-/react-native-video-controls-2.8.1.tgz#30ae707d8d218fed34bba3fc027b3943c5f438d9"
   integrity sha512-dBmrE3TAKaR1gYMfbukjAM6Xo8OMZyRrxPzZtnaUgWcvGo11PQwzaI/j8HPD5fLgO+rlweP2pDpEJyIBsJvJkw==


### PR DESCRIPTION
I wanted to be able to mark stuff as seen from the grid view without having to change t the list view.

Added the same functionality as rows have on Podcasts screen when swipping an item, to the grid item view long press action.

![Simulator Screen Shot - iPhone 14 Pro - 2023-02-02 at 22 03 20](https://user-images.githubusercontent.com/5912405/216510011-554b6241-9fb9-4fe5-abd5-b2a48e082437.png)
