### PR TITLE
fix action streaming => stream

### DIFF
--- a/src/services/v4v/v4v.ts
+++ b/src/services/v4v/v4v.ts
@@ -418,7 +418,7 @@ const sendValueTransactions = async (
 }
 
 export const processValueTransactionQueue = async () => {
-  const action = 'streaming'
+  const action = 'stream'
   const bundledValueTransactionsToProcess = await bundleValueTransactionQueue()
 
   // Hardcoding to Alby until another service is added.


### PR DESCRIPTION
This PR fixes the action for streaming sats.

According to bLIP-10 the action for streaming sats is "stream" not "streaming".
https://github.com/Podcastindex-org/podcast-namespace/blob/main/value/blip-0010.md