### PR TITLE
Disabled cleartext traffic for release builds. Updated deeplinking items to use https

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -114,7 +114,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:scheme="http"
+                    android:scheme="https"
                     android:host="podverse.fm"
                     android:pathPrefix="/podcast/" />
             </intent-filter>
@@ -125,7 +125,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:scheme="http"
+                    android:scheme="https"
                     android:host="podverse.fm"
                     android:pathPrefix="/profile/" />
             </intent-filter>
@@ -136,7 +136,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:scheme="http"
+                    android:scheme="https"
                     android:host="podverse.fm"
                     android:pathPrefix="/reset-password/" />
             </intent-filter>
@@ -147,7 +147,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:scheme="http"
+                    android:scheme="https"
                     android:host="podverse.fm"
                     android:pathPrefix="/about/" />
             </intent-filter>
@@ -158,7 +158,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:scheme="http"
+                    android:scheme="https"
                     android:host="podverse.fm"
                     android:pathPrefix="/contact/" />
             </intent-filter>
@@ -169,7 +169,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:scheme="http"
+                    android:scheme="https"
                     android:host="podverse.fm"
                     android:pathPrefix="/membership/" />
             </intent-filter>
@@ -180,7 +180,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:scheme="http"
+                    android:scheme="https"
                     android:host="podverse.fm"
                     android:pathPrefix="/contribute/" />
             </intent-filter>
@@ -191,18 +191,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:scheme="http"
-                    android:host="podverse.fm"
-                    android:pathPrefix="/profile/" />
-            </intent-filter>
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="http"
+                    android:scheme="https"
                     android:host="podverse.fm"
                     android:pathPrefix="/terms/" />
             </intent-filter>
@@ -213,7 +202,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data
-                    android:scheme="http"
+                    android:scheme="https"
                     android:host="podverse.fm"
                     android:pathPrefix="/xmpp/" />
             </intent-filter>

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true"/>
+    <base-config cleartextTrafficPermitted="false"/>
 </network-security-config>


### PR DESCRIPTION
DONT MERGE until 4.14.0 is release to production.

Make sure to ask Beta testers to confirm their podcasts are still working fine (playing episodes, seeing images etc).