### PR TITLE
fix: #1992

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9317,7 +9317,7 @@ react-native-text-ticker@1.13.0:
 
 "react-native-track-player@github:lovegaoshi/react-native-track-player#dev-podverse-aa":
   version "4.0.0-rc03"
-  resolved "https://codeload.github.com/lovegaoshi/react-native-track-player/tar.gz/469fdb4b3509998dbc47f354cd6e2f061482497a"
+  resolved "https://codeload.github.com/lovegaoshi/react-native-track-player/tar.gz/1c42368e71ffde744b083b008455e6e08784589f"
 
 react-native-tracking-transparency@0.1.1:
   version "0.1.1"


### PR DESCRIPTION
this should fix #1992.
the exact change is in the RNTP fork:
https://github.com/lovegaoshi/react-native-track-player/commit/2fc12bc15ec4b3fb5ff3807e45296a229e9b946d
the wake activity behavior in MusicService's onCreate is now wrapped with an if checking Settings.canDrawOverlays. wake is only invoked when that permission is enabled - lower end phones can opt out of this behavior only intended for use with android auto by simply not granting the draw over apps permission at all