### PR TITLE
Update transcriptor to version 1.1.4 to support speaker markers in VTT

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "standard": "16.0.3",
     "stream": "0.0.2",
     "timers": "0.1.1",
-    "transcriptator": "^1.1.0",
+    "transcriptator": "^1.1.4",
     "url": "^0.11.0",
     "validator": "13.7.0",
     "wd": "1.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7791,10 +7791,10 @@ node-gyp@^5.0.2, node-gyp@^5.1.1:
     tar "^4.4.12"
     which "^1.3.1"
 
-node-html-parser@^6.1.5:
-  version "6.1.10"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.10.tgz#5db11eac3ccbea6fc1b04a22c8a0e3a0774cfae6"
-  integrity sha512-6/uWdWxjQWQ7tMcFK2wWlrflsQUzh1HsEzlIf2j5+TtzfhT2yUvg3DwZYAmjEHeR3uX74ko7exjHW69J0tOzIg==
+node-html-parser@^6.1.12:
+  version "6.1.13"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.13.tgz#a1df799b83df5c6743fcd92740ba14682083b7e4"
+  integrity sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==
   dependencies:
     css-select "^5.1.0"
     he "1.2.0"
@@ -10992,12 +10992,12 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-transcriptator@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/transcriptator/-/transcriptator-1.1.3.tgz#9e02042ac069f86f0189e62ed78f02ab44face76"
-  integrity sha512-65CufQCYd8Z+UWVtQl78kKov6w5l/sNRFZ36O98N4Dv3D38uSaC5rRWKxsCYpVdw4ZaXWePzTxzmIjGXnzQalQ==
+transcriptator@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/transcriptator/-/transcriptator-1.1.4.tgz#b0c936c20267ab5e0e525cae2d88bb47e7ec3844"
+  integrity sha512-j5csEe3drdQag+z9BUZVQPSRIZICxpOMpDnyas6rE4kqd7yrIHEHun0QaXCtIQPbvvXGDyrnQQPvSL5/98wBvw==
   dependencies:
-    node-html-parser "^6.1.5"
+    node-html-parser "^6.1.12"
 
 traverse@^0.6.6:
   version "0.6.7"


### PR DESCRIPTION
In Transcriptator 1.1.4, I added support for speakers identified in VTT files with the syntax `<v speakerName>`. A question was posted on the Discord why they were seeing the names this way. I noticed Podverse hadn't updated yet. This make the necessary update.

Since I'm not setup for full Podverse development, I wasn't able to test to see if this broke anything. I don't believe it should since the change in Transcriptator was minor.