### PR TITLE
Fix loading on iOS CarPlay

### DIFF
--- a/src/services/playerAudioSetup.ts
+++ b/src/services/playerAudioSetup.ts
@@ -25,6 +25,7 @@ const setupPlayer = async (options: Parameters<typeof TrackPlayer.setupPlayer>[0
       await TrackPlayer.setupPlayer(options)
     } catch (error) {
       if (error?.code === 'android_cannot_setup_player_in_background') {
+        // try again if app in the background, foreground needed to setup successfully
         continue;
       }
 

--- a/src/services/playerAudioSetup.ts
+++ b/src/services/playerAudioSetup.ts
@@ -20,18 +20,18 @@ const iosCategoryOptions = [
 ]
 
 const setupPlayer = async (options: Parameters<typeof TrackPlayer.setupPlayer>[0]) => {
-  const setup = async () => {
+  while (1) {
     try {
       await TrackPlayer.setupPlayer(options)
     } catch (error) {
-      return (error as Error & { code?: string }).code
+      if (error?.code === 'android_cannot_setup_player_in_background') {
+        continue;
+      }
+
+      throw error;
     }
-  }
-  while ((await setup()) === 'android_cannot_setup_player_in_background') {
-    // A timeout will mostly only execute when the app is in the foreground,
-    // and even if we were in the background still, it will reject the promise
-    // and we'll try again:
-    await new Promise<void>((resolve) => setTimeout(resolve, 1))
+
+    break;
   }
 }
 


### PR DESCRIPTION
When building the Godcaster app we noticed that the track player would not load for iOS CarPlay when the phone screen was off. By eliminating setTimeout in loading code this allowed the app to load correctly while also still allowing Android to load properly too.

I'm seeing this same behavior in the Podverse App. I don't know if this fixes the problem totally because there may be other timeouts. But it at least fixes one.

Note, I think this is also easier to read and follow.